### PR TITLE
Allowing Headers to be overridden

### DIFF
--- a/lib/rack/robustness.rb
+++ b/lib/rack/robustness.rb
@@ -171,8 +171,8 @@ module Rack
       else
         status, headers, body = rescue_clause
         handle_status(ex, status)
-        handle_headers(ex, headers)
         handle_headers(ex, headers_clause)
+        handle_headers(ex, headers)
         handle_body(ex, body)
       end
     end


### PR DESCRIPTION
Overriding headers per-exception wasn't working due to the `||=` on line 186.  Also, the order of the handle_headers calls meant that the more global `headers_clause` superseded the localized `headers`, so I swapped them.
