### PR TITLE
fix: Check for `Integer` instead of Fixnum to avoid deprecation warning in ruby 2.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.4.0
   - ruby-head
   - jruby-19mode
   - jruby-head

--- a/lib/rack/robustness.rb
+++ b/lib/rack/robustness.rb
@@ -164,7 +164,7 @@ module Rack
     def handle_error(ex, rescue_clause)
       case rescue_clause
       when NilClass then handle_error(ex, [status_clause,  {},           body_clause])
-      when Fixnum   then handle_error(ex, [rescue_clause,  {},           body_clause])
+      when Integer  then handle_error(ex, [rescue_clause,  {},           body_clause])
       when String   then handle_error(ex, [status_clause,  {},           rescue_clause])
       when Hash     then handle_error(ex, [status_clause, rescue_clause, body_clause])
       when Proc     then handle_error(ex, handle_value(ex, rescue_clause))


### PR DESCRIPTION
I'm using `Rack::Robustness` in a Sinatra application that I recently upgraded to rails 2.4, i'm seeing the following deprecation notice:

```
/Users/me/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rack-robustness-1.1.0/lib/rack/robustness.rb:167: warning: constant ::Fixnum is deprecated
```

Integer is the superclass of Fixnum, so the case statement (which boils down to `Integer === rescue_clause`) is true for both `Fixnum` and `Integer` in ruby `2.4.0` and earlier ruby versions.

I also went ahead and added an explicit call out for `2.4.0` in `travis.yml` but I can easily remove that if you'd prefer it.